### PR TITLE
add-dracula-theme

### DIFF
--- a/lib/terminal-plus.coffee
+++ b/lib/terminal-plus.coffee
@@ -117,6 +117,7 @@ module.exports =
             'red-sands',
             'silver-aerogel',
             'solid-colors',
+            'dracula'
           ]
     ansiColors:
       type: 'object'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -11,4 +11,5 @@
   @import 'themes/red-sands';
   @import 'themes/silver-aerogel';
   @import 'themes/solid-colors';
+  @import 'themes/dracula';
 }

--- a/styles/themes/dracula.less
+++ b/styles/themes/dracula.less
@@ -1,0 +1,12 @@
+.dracula {
+  background-color: #1e1f29;
+  color: white;
+
+  ::selection {
+    background-color: #44475a;
+  }
+
+  .terminal-cursor {
+    background-color: #999999;
+  }
+}


### PR DESCRIPTION
This theme is a port of the [dracula theme](https://github.com/zenorocha/dracula-theme/) for terminal-plus.

Here is an screenshot of how it looks (colors are highlighted by the [fish shell](http://fishshell.com) - font Ruboto Mono):

![dracula terminal plus](http://oi67.tinypic.com/fawqck.jpg)

