### PR TITLE
add copyAllToNewFile

### DIFF
--- a/keymaps/terminal-plus.cson
+++ b/keymaps/terminal-plus.cson
@@ -17,7 +17,9 @@
 '.platform-darwin .terminal-plus .terminal':
   'cmd-c': 'terminal-plus:copy'
   'cmd-v': 'terminal-plus:paste'
+  'alt-cmd-c': 'terminal-plus:copy-all-to-new-file'
 
 '.platform-linux .terminal-plus .terminal, .platform-win32 .terminal-plus .terminal':
   'alt-v': 'terminal-plus:paste'
   'alt-c': 'terminal-plus:copy'
+  'alt-ctrl-c': 'terminal-plus:copy-all-to-new-file'

--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -41,6 +41,7 @@ class StatusBar extends View
     @subscriptions.add atom.commands.add '.xterm',
       'terminal-plus:paste': => @runInActiveView (i) -> i.paste()
       'terminal-plus:copy': => @runInActiveView (i) -> i.copy()
+      'terminal-plus:copy-all-to-new-file': => @runInActiveView (i) -> i.copyAllToNewFile()
 
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem (item) =>
       return unless item?

--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -410,6 +410,16 @@ class TerminalPlusView extends View
   paste: ->
     @input atom.clipboard.read()
 
+  copyAllToNewFile: ->
+    text = @terminal.lines.map (line) ->
+      line.map (cols) ->
+        cols[1]
+      .join('').trimRight() + '\n'
+    .join('').replace(/\n*?$/g, '') + '\n';
+
+    atom.workspace.open().then (editor) ->
+      editor.insertText(text)
+
   insertSelection: ->
     return unless editor = atom.workspace.getActiveTextEditor()
     runCommand = atom.config.get('terminal-plus.toggles.runInsertedText')

--- a/menus/terminal-plus.cson
+++ b/menus/terminal-plus.cson
@@ -18,6 +18,7 @@
   '.terminal-plus .terminal': [
     {label: 'Copy', command: 'terminal-plus:copy'},
     {label: 'Paste', command: 'terminal-plus:paste'},
+    {label: 'Copy All to New File', command: 'terminal-plus:copy-all-to-new-file'},
     {type: 'separator'},
     {label: 'Hide', command: 'terminal-plus:hide'},
     {label: 'Close', command: 'terminal-plus:close'}


### PR DESCRIPTION
This copies all the lines in the terminal (not just the visible ones) and dumps it in a new file. This is to get around the fact that you can't select (and therefore can't copy) more text than is displayed in the current terminal view.
