### PR TITLE
Fullscreen menu/keybinding (Solves #108)

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -37,6 +37,7 @@ class StatusBar extends View
       'terminal-plus:rename': => @runInActiveView (i) -> i.rename()
       'terminal-plus:insert-selected-text': => @runInActiveView (i) -> i.insertSelection()
       'terminal-plus:insert-text': => @runInActiveView (i) -> i.inputDialog()
+      'terminal-plus:fullscreen': => @activeTerminal.maximize()
 
     @subscriptions.add atom.commands.add '.xterm',
       'terminal-plus:paste': => @runInActiveView (i) -> i.paste()

--- a/menus/terminal-plus.cson
+++ b/menus/terminal-plus.cson
@@ -45,6 +45,10 @@
           'command': 'terminal-plus:next'
         },
         {
+          'label': 'Toggle Fullscreen'
+          'command': 'terminal-plus:fullscreen'
+        },
+        {
           'label': 'Close Terminal'
           'command': 'terminal-plus:close'
         },


### PR DESCRIPTION
Adds 'Toggle Fullscreen' option to the 'terminal-plus' menu commands. Keybinding is not included by default, but once you have 'terminal-plus:fullscreen' - it's easy to add one per your liking :)