### PR TITLE
Add deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTICE: This package is no longer maintained
+
+Terminal-Plus is no longer maintained and **does not work** on the latest version of Atom. Please use an up-to-date fork (such as [platformio-atom-ide-terminal](https://github.com/platformio/platformio-atom-ide-terminal)) instead.
+
 ## Author's Note
 * Please make sure you are on the [latest version of Atom](https://atom.io/releases) before reporting bugs!
 * This package requires that you have the dependencies for node-gyp.  


### PR DESCRIPTION
Since this package no longer works in the latest version of Atom (#234 #233, #232, #231, #230 #227, #225, #224, etc), I suggest you add a notice to the README indicating this to save others the trouble of trying to get this to work in the future.