### PR TITLE
Replace pty.js with ptyw.js

### DIFF
--- a/lib/process.coffee
+++ b/lib/process.coffee
@@ -1,4 +1,4 @@
-pty = require 'pty.js'
+pty = require 'ptyw.js'
 path = require 'path'
 fs = require 'fs'
 _ = require 'underscore'

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
-    "pty.js": "git+https://github.com/jeremyramin/pty.js.git#28f2667",
     "ptyw.js": "0.3.x",
     "term.js": "git+https://github.com/jeremyramin/term.js.git",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
     "pty.js": "git+https://github.com/jeremyramin/pty.js.git#28f2667",
+    "ptyw.js": "0.3.x",
     "term.js": "git+https://github.com/jeremyramin/term.js.git",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
I don't know if it's the fork you are maintaining or if electron v1+ is just not working with nan to compile native modules - but replacing pty.js with ptyw.js allows for it to work.

electron v1.1.1
atom 1.90-dev
