### PR TITLE
Fixes issue #277

### DIFF
--- a/lib/status-bar.coffee
+++ b/lib/status-bar.coffee
@@ -89,7 +89,8 @@ class StatusBar extends View
     handleFocus = =>
       if @returnFocus
         setTimeout =>
-          @returnFocus.focus()
+          if @returnFocus
+            @returnFocus.focus()
           @returnFocus = null
         , 100
 


### PR DESCRIPTION
Looks like a mini-race condition where if `handleFocus` is fired within 100ms of the previous `handleFocus` then `@returnFocus` will be null.

This should fix the problem, but let me know if you'd like to solve the issue differently.