### PR TITLE
Fix OSX/macOS keybinding conflict

### DIFF
--- a/keymaps/terminal-plus.cson
+++ b/keymaps/terminal-plus.cson
@@ -1,8 +1,8 @@
 '.platform-darwin atom-workspace':
-  'cmd-shift-t': 'terminal-plus:new'
-  'cmd-shift-j': 'terminal-plus:prev'
-  'cmd-shift-k': 'terminal-plus:next'
-  'cmd-shift-x': 'terminal-plus:close'
+  'alt-shift-t': 'terminal-plus:new'
+  'alt-shift-j': 'terminal-plus:prev'
+  'alt-shift-k': 'terminal-plus:next'
+  'alt-shift-x': 'terminal-plus:close'
   'ctrl-enter': 'terminal-plus:insert-selected-text'
   'ctrl-`': 'terminal-plus:toggle'
 


### PR DESCRIPTION
The binding `cmd-shift-t` was in conflict with Atom's default "Reopen Last Item" keybinding, as noted in #172 and #216.

This changes the keybindings for OSX's `atom-workspace` to use `alt-shift`, which does not have conflicts with default packages. For consistency, all of them have been changed.