### PR TITLE
Update dep pty.js to v0.3.1 - fixes issue #362

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
-    "pty.js": "git+https://github.com/jeremyramin/pty.js.git#f6b5a5a",
+    "pty.js": "git+https://github.com/jeremyramin/pty.js.git#fe63a41",
     "term.js": "git+https://github.com/jeremyramin/term.js.git",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Updating pty.js to v0.3.1 fixes the issue #362 for my specific setup (Ubuntu 16.04, x64):

```
$ apm -v
apm  1.12.5
npm  3.10.5
node 4.4.5
python 2.7.12
git 2.7.4
```
