### PR TITLE
add solarized light theme

### DIFF
--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -131,7 +131,8 @@ module.exports =
         'red-sands',
         'silver-aerogel',
         'solid-colors',
-        'dracula'
+        'dracula',
+        'solarized-light'
       ]
   ansiColors:
     type: 'object'

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -12,4 +12,5 @@
   @import 'themes/silver-aerogel';
   @import 'themes/solid-colors';
   @import 'themes/dracula';
+  @import 'themes/solarized-light';
 }

--- a/styles/themes/solarized-light.less
+++ b/styles/themes/solarized-light.less
@@ -1,6 +1,6 @@
 .solarized-light {
   background-color: #fdf6e3;
-  color: #586e75;
+  color: #657b83;
 
   ::selection {
     background-color: #eee8d5;

--- a/styles/themes/solarized-light.less
+++ b/styles/themes/solarized-light.less
@@ -1,0 +1,12 @@
+.solarized-light {
+  background-color: #fdf6e3;
+  color: #586e75;
+
+  ::selection {
+    background-color: #eee8d5;
+  }
+
+  .terminal-cursor {
+    background-color: #002b36;
+  }
+}


### PR DESCRIPTION
Similar to the `novel` theme but matches the Atom syntax theme for solarized-light.