### PR TITLE
Fixed #402: Removed Commit-id that causes blinking caret

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
-    "pty.js": "git+https://github.com/jeremyramin/pty.js.git#f6b5a5a",
+    "pty.js": "git+https://github.com/jeremyramin/pty.js.git",
     "term.js": "git+https://github.com/jeremyramin/term.js.git",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
```- "pty.js": "git+https://github.com/jeremyramin/pty.js.git#f6b5a5a"```
```+ "pty.js": "git+https://github.com/jeremyramin/pty.js.git"```
